### PR TITLE
Reduce time taken from tapping ticket token in wallet to ticket list appearing

### DIFF
--- a/AlphaWallet/AssetDefinition/AssetAttribute.swift
+++ b/AlphaWallet/AssetDefinition/AssetAttribute.swift
@@ -23,7 +23,7 @@ enum AssetAttributeSyntax: String {
             if isMapping {
                 return string
             } else {
-                guard let value = BigInt(string) else { return "" }
+                guard let value = BigUInt(string) else { return "" }
                 return String(data: Data(bytes: String(value, radix: 16).hexa2Bytes), encoding: .utf8)
             }
         case .integer:
@@ -33,14 +33,14 @@ enum AssetAttributeSyntax: String {
 }
 
 enum AssetAttribute {
-    case mapping(attribute: XML.Accessor, syntax: AssetAttributeSyntax, lang: String, bitmask: BigInt, bitShift: Int)
-    case direct(attribute: XML.Accessor, syntax: AssetAttributeSyntax, bitmask: BigInt, bitShift: Int)
+    case mapping(attribute: XML.Accessor, syntax: AssetAttributeSyntax, lang: String, bitmask: BigUInt, bitShift: Int)
+    case direct(attribute: XML.Accessor, syntax: AssetAttributeSyntax, bitmask: BigUInt, bitShift: Int)
 
     init(attribute: XML.Element, lang: String) {
         self = {
             let attributeAccessor = XML.Accessor(attribute)
             //TODO show error if syntax attribute is missing
-            if case .singleElement(let origin) = attributeAccessor["origin"], let rawSyntax = attributeAccessor.attributes["syntax"], let syntax = AssetAttributeSyntax(rawValue: rawSyntax), let type = XML.Accessor(origin).attributes["as"], let bitmaskString = AssetAttribute.getBitMaskFrom(attribute: attributeAccessor), let bitmask = BigInt(bitmaskString, radix: 16) {
+            if case .singleElement(let origin) = attributeAccessor["origin"], let rawSyntax = attributeAccessor.attributes["syntax"], let syntax = AssetAttributeSyntax(rawValue: rawSyntax), let type = XML.Accessor(origin).attributes["as"], let bitmaskString = AssetAttribute.getBitMaskFrom(attribute: attributeAccessor), let bitmask = BigUInt(bitmaskString, radix: 16) {
                 let bitShift = AssetAttribute.bitShiftCount(forBitMask: bitmask)
                 switch type {
                 case "mapping":
@@ -50,27 +50,26 @@ enum AssetAttribute {
                 }
             }
             //TODO maybe return an optional to indicate error instead?
-            return .direct(attribute: attributeAccessor, syntax: .iA5String, bitmask: BigInt(0), bitShift: 0)
+            return .direct(attribute: attributeAccessor, syntax: .iA5String, bitmask: BigUInt(0), bitShift: 0)
         }()
     }
 
-    func extract<T>(from tokenValueHex: String) -> T? where T: AssetAttributeValue {
+    func extract<T>(from tokenValue: BigUInt) -> T? where T: AssetAttributeValue {
         switch self {
         case .mapping(let attribute, let syntax, let lang, _, _):
-            guard let key = parseValue(tokenValueHex: tokenValueHex) else { return nil }
+            guard let key = parseValue(tokenValue: tokenValue) else { return nil }
             guard let value = attribute["origin"]["option"].getElementWithKeyAttribute(equals: String(key))?["value"].getElementWithLangAttribute(equals: lang)?.text else { return nil }
             return syntax.extract(from: value, isMapping: true) as? T
         case .direct(_, let syntax, _, _):
-            guard let value = parseValue(tokenValueHex: tokenValueHex) else { return nil }
+            guard let value = parseValue(tokenValue: tokenValue) else { return nil }
             return syntax.extract(from: String(value), isMapping: false) as? T
         }
     }
 
-    private func parseValue(tokenValueHex: String) -> BigInt? {
+    private func parseValue(tokenValue: BigUInt) -> BigUInt? {
         switch self {
         case .direct(let attribute, _, let bitmask, let bitShift), .mapping(let attribute, _, _, let bitmask, let bitShift):
-            guard let tokenHexAsInt = BigInt(tokenValueHex, radix: 16) else { return nil }
-            return (bitmask & tokenHexAsInt) >> bitShift
+            return (bitmask & tokenValue) >> bitShift
         }
     }
 
@@ -79,7 +78,7 @@ enum AssetAttribute {
     }
 
     ///Used to truncate bits to the right of the bitmask
-    private static func bitShiftCount(forBitMask bitmask: BigInt) -> Int {
+    private static func bitShiftCount(forBitMask bitmask: BigUInt) -> Int {
         var count = 0
         repeat {
             count += 1

--- a/AlphaWallet/AssetDefinition/XMLHandler.swift
+++ b/AlphaWallet/AssetDefinition/XMLHandler.swift
@@ -27,23 +27,20 @@ private class PrivateXMLHandler {
     }
 
     func getFifaInfoForTicket(tokenId tokenBytes32: BigUInt, index: UInt16) -> Ticket {
-        //check if leading or trailing zeros
-        let tokenId = tokenBytes32
-        guard tokenId != 0 else { return .empty }
+        guard tokenBytes32 != 0 else { return .empty }
         let lang = getLang()
-        let tokenHex = MarketQueueHandler.bytesToHexa(tokenBytes32.serialize().bytes)
 
-        let locality: String = fields["locality"]?.extract(from: tokenHex) ?? "N/A"
-        let venue: String = fields["venue"]?.extract(from: tokenHex) ?? "N/A"
-        let time: GeneralisedTime = fields["time"]?.extract(from: tokenHex) ?? .init()
-        let countryA: String = fields["countryA"]?.extract(from: tokenHex) ?? ""
-        let countryB: String = fields["countryB"]?.extract(from: tokenHex) ?? ""
-        let match: Int = fields["match"]?.extract(from: tokenHex) ?? 0
-        let category: String = fields["category"]?.extract(from: tokenHex) ?? "N/A"
-        let numero: Int = fields["numero"]?.extract(from: tokenHex) ?? 0
+        let locality: String = fields["locality"]?.extract(from: tokenBytes32) ?? "N/A"
+        let venue: String = fields["venue"]?.extract(from: tokenBytes32) ?? "N/A"
+        let time: GeneralisedTime = fields["time"]?.extract(from: tokenBytes32) ?? .init()
+        let countryA: String = fields["countryA"]?.extract(from: tokenBytes32) ?? ""
+        let countryB: String = fields["countryB"]?.extract(from: tokenBytes32) ?? ""
+        let match: Int = fields["match"]?.extract(from: tokenBytes32) ?? 0
+        let category: String = fields["category"]?.extract(from: tokenBytes32) ?? "N/A"
+        let numero: Int = fields["numero"]?.extract(from: tokenBytes32) ?? 0
 
         return Ticket(
-                id: MarketQueueHandler.bytesToHexa(tokenId.serialize().array),
+                id: String(tokenBytes32, radix: 16),
                 index: index,
                 city: locality,
                 name: getName(lang: lang),

--- a/AlphaWallet/Transactions/Coordinators/TicketsCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TicketsCoordinator.swift
@@ -64,11 +64,8 @@ class TicketsCoordinator: NSObject, Coordinator {
     }
 
     func start() {
-        let viewModel = TicketsViewModel(
-            token: token
-        )
         rootViewController.tokenObject = token
-        rootViewController.configure(viewModel: viewModel)
+        rootViewController.configure()
         navigationController.viewControllers = [rootViewController]
         refreshUponAssetDefinitionChanges()
     }


### PR DESCRIPTION
Stumbled on this while looking at kitties.

With this PR, from a few random sampling, ticket list takes 20-30% less time to appear.

* Removed some extraneous back-and-forth conversion between token ID's integral and string forms
* Removed some unnecessary code that complicates the logic for XML parsing