### PR TITLE
Prompt user to go to Settings app, with explanation, while trying to scan QR code, if camera access was denied previously.

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -273,6 +273,7 @@
 		442FCE2BEE8D475C7DEB39C1 /* RedeemTicketsQuantitySelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442FC54DA900FA2F9BB73A63 /* RedeemTicketsQuantitySelectionViewModel.swift */; };
 		442FCED8B618930EFD1F7BA8 /* GetIsERC875Encode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442FCA1F19B6293FE5FAD494 /* GetIsERC875Encode.swift */; };
 		4AEDE35A1DC3B1F4B885A073 /* Pods_AlphaWallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BD60178B937124277D81CCD /* Pods_AlphaWallet.framework */; };
+		5E7C700A0B11504AC44718DD /* CanScanQRCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C74159ED115D14384A1CB /* CanScanQRCode.swift */; };
 		5E7C701BFF4469B35A074EB9 /* RequestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C767497AD8DEE83F384D7 /* RequestViewModel.swift */; };
 		5E7C70AE62DBB193399C7F5E /* ServerViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7CDB0BAD5D27D2F24F57 /* ServerViewCell.swift */; };
 		5E7C70BE9AE35408038E1971 /* HelpContentsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7B089FD4C96810DD10FD /* HelpContentsViewController.swift */; };
@@ -846,6 +847,7 @@
 		5E7C73DF5FBFE756097D32B1 /* EthCurrencyHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EthCurrencyHelper.swift; sourceTree = "<group>"; };
 		5E7C73ED9226646D562B5A3C /* UIStackView+Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStackView+Array.swift"; sourceTree = "<group>"; };
 		5E7C741196D9D9C9C3EE5E30 /* LockCreatePasscodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockCreatePasscodeViewController.swift; sourceTree = "<group>"; };
+		5E7C74159ED115D14384A1CB /* CanScanQRCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CanScanQRCode.swift; sourceTree = "<group>"; };
 		5E7C7419F47CC8B2996AA8F9 /* TransferTicketsQuantitySelectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransferTicketsQuantitySelectionViewController.swift; sourceTree = "<group>"; };
 		5E7C743172FCBDCD362C03A6 /* ImportWalletTabBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImportWalletTabBar.swift; sourceTree = "<group>"; };
 		5E7C7487BDF72352446E1266 /* ImportTicketViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImportTicketViewControllerTests.swift; sourceTree = "<group>"; };
@@ -1973,6 +1975,7 @@
 				5E7C727433F7B8E322B3C68A /* SetTransferTicketsExpiryDateViewController.swift */,
 				5E7C7D46C7CABC31A7477F37 /* GenerateTransferMagicLinkViewController.swift */,
 				5E7C78B63FDE2FAF25389260 /* TransferTicketsViaWalletAddressViewController.swift */,
+				5E7C74159ED115D14384A1CB /* CanScanQRCode.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -3702,6 +3705,7 @@
 				76F1D439D545AA9B7E686DCC /* ContractERC721Transfer.swift in Sources */,
 				5E7C79DE8864702C51C0A7CC /* ResultResult.swift in Sources */,
 				5E7C7AE2EF04A23EC7C5ADFD /* ImportTicketViewController.swift in Sources */,
+				5E7C700A0B11504AC44718DD /* CanScanQRCode.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -276,3 +276,6 @@
 "unknown.error" = "An unknown error occurred.";
 "coming.soon" = "Coming soon";
 "backupPassword.confirmation.mustMatch" = "You must enter the same passsword in Password and Confirm Password";
+"camera.qrCode.denied.prompt.title" = "Camera Access Required to Scan QR Code";
+"camera.qrCode.denied.prompt.message" = "Your privacy settings are preventing us from accessing your camera for QR code scanning. Fix this by:\n\n1. Tap the Open Settings button below to open the Settings app.\n\n2. Tap to enable the Camera on.\n\n3. Launch this app again.";
+"camera.qrCode.denied.prompt.button" = "Open Settings";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -276,3 +276,6 @@
 "unknown.error" = "An unknown error occurred.";
 "coming.soon" = "Coming soon";
 "backupPassword.confirmation.mustMatch" = "You must enter the same passsword in Password and Confirm Password";
+"camera.qrCode.denied.prompt.title" = "Camera Access Required to Scan QR Code";
+"camera.qrCode.denied.prompt.message" = "Your privacy settings are preventing us from accessing your camera for QR code scanning. Fix this by:\n\n1. Tap the Open Settings button below to open the Settings app.\n\n2. Tap to enable the Camera on.\n\n3. Launch this app again.";
+"camera.qrCode.denied.prompt.button" = "Open Settings";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -276,3 +276,6 @@
 "unknown.error" = "出现未知错误.";
 "coming.soon" = "近期开放";
 "backupPassword.confirmation.mustMatch" = "请输入相同的密码进行确认";
+"camera.qrCode.denied.prompt.title" = "Camera Access Required to Scan QR Code";
+"camera.qrCode.denied.prompt.message" = "Your privacy settings are preventing us from accessing your camera for QR code scanning. Fix this by:\n\n1. Tap the Open Settings button below to open the Settings app.\n\n2. Tap to enable the Camera on.\n\n3. Launch this app again.";
+"camera.qrCode.denied.prompt.button" = "Open Settings";

--- a/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/NewTokenViewController.swift
@@ -10,7 +10,7 @@ protocol NewTokenViewControllerDelegate: class {
     func didAddAddress(address: String, in viewController: NewTokenViewController)
 }
 
-class NewTokenViewController: UIViewController {
+class NewTokenViewController: UIViewController, CanScanQRCode {
     let roundedBackground = RoundedBackground()
     let scrollView = UIScrollView()
     let footerBar = UIView()
@@ -330,6 +330,10 @@ extension NewTokenViewController: AddressTextFieldDelegate {
     }
 
     func openQRCodeReader(for textField: AddressTextField) {
+        guard AVCaptureDevice.authorizationStatus(for: .video) != .denied else {
+            promptUserOpenSettingsToChangeCameraPermission()
+            return
+        }
         let controller = QRCodeReaderViewController()
         controller.delegate = self
         present(controller, animated: true, completion: nil)

--- a/AlphaWallet/Transfer/ViewControllers/CanScanQRCode.swift
+++ b/AlphaWallet/Transfer/ViewControllers/CanScanQRCode.swift
@@ -1,0 +1,26 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import UIKit
+
+protocol CanScanQRCode: class {
+    func promptUserOpenSettingsToChangeCameraPermission()
+}
+
+extension CanScanQRCode where Self: UIViewController {
+    func promptUserOpenSettingsToChangeCameraPermission() {
+        //TODO app will be killed by iOS after user changes camera permission. Ideally, we should note that the user has reached here and on app launch, prompt user if they want to resume
+        confirm(
+                title: R.string.localizable.cameraQrCodeDeniedPromptTitle(),
+                message: R.string.localizable.cameraQrCodeDeniedPromptMessage(),
+                okTitle: R.string.localizable.cameraQrCodeDeniedPromptButton(),
+                okStyle: .default
+        ) { result in
+            switch result {
+            case .success:
+                UIApplication.shared.open(URL(string: UIApplicationOpenSettingsURLString)!, options: [:], completionHandler: nil)
+            case .failure:
+                break
+            }
+        }
+    }
+}

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -19,7 +19,7 @@ protocol SendViewControllerDelegate: class {
     )
 }
 
-class SendViewController: UIViewController {
+class SendViewController: UIViewController, CanScanQRCode {
     let roundedBackground = RoundedBackground()
     let header = SendHeaderView()
     let targetAddressTextField = AddressTextField()
@@ -564,6 +564,10 @@ extension SendViewController: AddressTextFieldDelegate {
     }
 
     func openQRCodeReader(for textField: AddressTextField) {
+        guard AVCaptureDevice.authorizationStatus(for: .video) != .denied else {
+            promptUserOpenSettingsToChangeCameraPermission()
+            return
+        }
         let controller = QRCodeReaderViewController()
         controller.delegate = self
         present(controller, animated: true, completion: nil)

--- a/AlphaWallet/Transfer/ViewControllers/TransferTicketsViaWalletAddressViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/TransferTicketsViaWalletAddressViewController.swift
@@ -9,7 +9,7 @@ protocol TransferTicketsViaWalletAddressViewControllerDelegate: class {
     func didPressViewContractWebPage(in viewController: TransferTicketsViaWalletAddressViewController)
 }
 
-class TransferTicketsViaWalletAddressViewController: UIViewController, TicketVerifiableStatusViewController {
+class TransferTicketsViaWalletAddressViewController: UIViewController, TicketVerifiableStatusViewController, CanScanQRCode {
     let config: Config
     var contract: String {
         return token.contract
@@ -169,6 +169,10 @@ extension TransferTicketsViaWalletAddressViewController: AddressTextFieldDelegat
     }
 
     func openQRCodeReader(for textField: AddressTextField) {
+        guard AVCaptureDevice.authorizationStatus(for: .video) != .denied else {
+            promptUserOpenSettingsToChangeCameraPermission()
+            return
+        }
         let controller = QRCodeReaderViewController()
         controller.delegate = self
         present(controller, animated: true, completion: nil)

--- a/AlphaWallet/Wallet/ViewControllers/ImportWalletViewController.swift
+++ b/AlphaWallet/Wallet/ViewControllers/ImportWalletViewController.swift
@@ -8,7 +8,7 @@ protocol ImportWalletViewControllerDelegate: class {
     func didImportAccount(account: Wallet, in viewController: ImportWalletViewController)
 }
 
-class ImportWalletViewController: UIViewController {
+class ImportWalletViewController: UIViewController, CanScanQRCode {
     struct ValidationError: LocalizedError {
         var msg: String
         var errorDescription: String? {
@@ -310,6 +310,10 @@ class ImportWalletViewController: UIViewController {
     }
 
     @objc func openReader() {
+        guard AVCaptureDevice.authorizationStatus(for: .video) != .denied else {
+            promptUserOpenSettingsToChangeCameraPermission()
+            return
+        }
         let controller = QRCodeReaderViewController()
         controller.delegate = self
         present(controller, animated: true, completion: nil)


### PR DESCRIPTION
For #569.

This PR, will upon tapping camera icon (various screens, including add a token) and if camera access is already denied previously:

1. Show a dialog with explanation
2. User taps button in dialog to switch to the Settings app where they can just tap a switch to enable access.
3. User launch to app again and re-try what they were doing.

@James-Sangalli iOS, unfortunately, kills the app after camera access is changed, so the user will have to manually launch the app again, navigate to where they were (e.g sending ETH) and repeat their process. Ideally, we should track where they were (what they have entered so far) and try our best to let the user resume. But there are 4 screens where this is needed. So if this is important, create an issue :)