### PR TITLE
Remove unnecessary try! where it's possible to continue to reduce crashes

### DIFF
--- a/AlphaWallet/AssetDefinition/XMLHandler.swift
+++ b/AlphaWallet/AssetDefinition/XMLHandler.swift
@@ -22,7 +22,8 @@ private class PrivateXMLHandler {
     init(contract: String) {
         contractAddress = contract.add0x.lowercased()
         let assetDefinitionStore = AssetDefinitionStore()
-        xml = try! XML.parse(assetDefinitionStore[contract] ?? "")
+        //We use a try? for the first parse() instead of try! to avoid the very unlikely chance that it will crash. We fallback to an empty XML just like if we haven't downloaded it yet
+        xml = (try? XML.parse(assetDefinitionStore[contract] ?? "")) ?? (try! XML.parse(""))
         isOfficial = assetDefinitionStore.isOfficial(contract: contract)
     }
 

--- a/AlphaWallet/Tokens/ViewControllers/StaticHTMLViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/StaticHTMLViewController.swift
@@ -16,7 +16,7 @@ class StaticHTMLViewController: UIViewController {
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.delegate = self
         if let path = url() {
-            let html = try! String(contentsOf: path)
+            let html = (try? String(contentsOf: path)) ?? ""
             webView.loadHTMLString(html, baseURL: URL(fileURLWithPath: Bundle.main.bundlePath))
         }
         view.addSubview(webView)


### PR DESCRIPTION
Similar to #567, removing/replacing the `try!`(s) with `try?` where it's reasonable for the app to continue running and not crash.

There are still many uses of `try!` that are kept around, but those are datastore/keystore access. Those are still preserved because there isn't an easy way for the app to continue to run.