### PR TITLE
Run tests on Travis directly with `xcodebuild` instead of fastlane

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 script:
   - set -o pipefail
-  - fastlane travis_tests
+  - xcodebuild -workspace AlphaWallet.xcworkspace -scheme AlphaWalletTests -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone X" test | xcpretty
 
 after_success:
   - bash <(curl -s https://copilot.blackducksoftware.com/ci/travis/scripts/upload)


### PR DESCRIPTION
With this PR, tests should still fail, but at least Travis will give a hint of which test(s) failed.

> Executed 161 tests, with 1 failure (0 unexpected) in 3.722 (4.230) seconds

> Failing tests:
>	InCoordinatorTests.testShowRequstFlow()
> ** TEST FAILED **