### PR TITLE
Fixes broken send ERC 20 UI

### DIFF
--- a/AlphaWallet/Sell/Views/AmountTextField.swift
+++ b/AlphaWallet/Sell/Views/AmountTextField.swift
@@ -48,6 +48,11 @@ class AmountTextField: UIControl {
         }
     }
     var currentPair: Pair
+    var isFiatButtonHidden: Bool = false {
+        didSet {
+            textField.rightView?.isHidden = isFiatButtonHidden
+        }
+    }
     private let textField = UITextField()
     let alternativeAmountLabel = UILabel()
     let fiatButton = Button(size: .normal, style: .borderless)

--- a/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
+++ b/AlphaWallet/Transfer/ViewControllers/SendViewController.swift
@@ -97,10 +97,16 @@ class SendViewController: UIViewController, CanScanQRCode {
 
         amountTextField.translatesAutoresizingMaskIntoConstraints = false
         amountTextField.delegate = self
-        ethPrice.subscribe { [weak self] value in
+        switch transferType {
+        case .ether:
+            ethPrice.subscribe { [weak self] value in
             if let value = value {
                 self?.amountTextField.ethToDollarRate = value
             }
+        }
+        default:
+            amountTextField.alternativeAmountLabel.isHidden = true
+            amountTextField.isFiatButtonHidden = true
         }
 
         myAddressContainer.translatesAutoresizingMaskIntoConstraints = false
@@ -203,6 +209,7 @@ class SendViewController: UIViewController, CanScanQRCode {
 
         view.backgroundColor = viewModel.backgroundColor
 
+        headerViewModel.showAlternativeAmount = viewModel.showAlternativeAmount
         header.configure(viewModel: headerViewModel)
 
         targetAddressLabel.font = viewModel.textFieldsLabelFont

--- a/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
+++ b/AlphaWallet/Transfer/ViewModels/SendHeaderViewViewModel.swift
@@ -7,6 +7,7 @@ struct SendHeaderViewViewModel {
     var ticker: CoinTicker?
     var currencyAmount: String?
     var currencyAmountWithoutSymbol: Double?
+    var showAlternativeAmount = false
 
     var issuer: String {
         return ""

--- a/AlphaWallet/Transfer/Views/SendHeaderView.swift
+++ b/AlphaWallet/Transfer/Views/SendHeaderView.swift
@@ -119,5 +119,7 @@ class SendHeaderView: UIView {
         valueLabel.textColor = viewModel.textColor
         valueLabel.font = viewModel.textValueFont
         valueLabel.text = viewModel.value
+
+        footerStackView?.isHidden = !viewModel.showAlternativeAmount
     }
 }


### PR DESCRIPTION
For #642.

This PR fixes these bugs introduced in an earlier commit:

* Should not display equivalent value (and appreciation/change) in ETH
* Should not show ETH button
* Should not show equivalent fiat value