### PR TITLE
Disable iTunes File Sharing for overriding asset definition

### DIFF
--- a/AlphaWallet/Info.plist
+++ b/AlphaWallet/Info.plist
@@ -68,8 +68,6 @@
 		<string>SourceSansPro-Semibold.otf</string>
 		<string>SourceSansPro-SemiboldIt.otf</string>
 	</array>
-	<key>UIFileSharingEnabled</key>
-	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
For #660 