### PR TITLE
Clear web3.currentProvider.isTrust so AirSwap prompts don't mention Trust

### DIFF
--- a/AlphaWallet/Browser/Factory/WKWebViewConfiguration.swift
+++ b/AlphaWallet/Browser/Factory/WKWebViewConfiguration.swift
@@ -78,6 +78,7 @@ extension WKWebViewConfiguration {
         web3.eth.getCoinbase = function(cb) {
             return cb(null, addressHex)
         }
+        web3.currentProvider.isTrust = false
 
         """
         let userScript = WKUserScript(source: js, injectionTime: .atDocumentStart, forMainFrameOnly: false)


### PR DESCRIPTION
For #665

I found 3 instances where it's affected (not sure if there're more):

1. "CONNECT USING TRUST" -> "CONNECT VIA WEB3"
2. "Connect with Trust" + icon. -> "Connect with" (**no wallet name**!) + What looks like the Metamask icon
3. "Please set Trust to use Main Network" -> "Please set web3 to use Main Network".

@James-Sangalli not sure if it's good to merge?

**Update**: Also because this PR clears the `isTrust` flag it *might* break dapps that check for it.

---

It looks like a more "proper" integration involves:

> Using an Ethereum wallet makes it easy to make trades on the go. When we announced #airswapgo we decided to build for mobile out of the box. Try it today using a mobile wallet like Trust Wallet. If you’re an Ethereum wallet developer, we’d love to collaborate. Reach us at partner@airswap.io.

From: https://blog.airswap.io/airswap-is-here-c83c001d5bbe

Looks like they support (at least:) Trust, Ledger, Trezor, and MetaMask.

Outside of formality, I imagine integration might be as easy as providing an icon and with this code:

    web3.currentProvider.isAlphaWallet = true

(Anyway, the `isAlphaWallet` flag will have to be thought about at some point)