### PR TITLE
Fix: presented dapp browser's Done button disappears after a transaction

### DIFF
--- a/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BrowserViewController.swift
@@ -61,7 +61,7 @@ final class BrowserViewController: UIViewController {
 
     weak var delegate: BrowserViewControllerDelegate?
 
-    var browserNavBar: BrowserNavigationBar? {
+    private var browserNavBar: BrowserNavigationBar? {
         return navigationController?.navigationBar as? BrowserNavigationBar
     }
 
@@ -80,6 +80,8 @@ final class BrowserViewController: UIViewController {
     }()
 
     let server: RPCServer
+
+    var isCloseButtonVisibilityConfigured = false
 
     init(
         account: Wallet,
@@ -242,6 +244,13 @@ final class BrowserViewController: UIViewController {
             }
             errorView.show(error: error)
         }
+    }
+
+    /// This function is expected to be called at most once (hence "setup"), subsequent calls will be ignored. This is important because it's designed to be called from a viewWillAppear(), checking if the browser is being presented and we decide if we want to show the close button then. It shouldn't be changed, e.g. when we present another view controller over the browser and close it (this time the browser wouldn't be presented anymore and hiding the close button will be wrong)
+    func setUpCloseButtonAs(hidden: Bool) {
+        guard !isCloseButtonVisibilityConfigured else { return }
+        isCloseButtonVisibilityConfigured = true
+        browserNavBar?.closeButton.isHidden = hidden
     }
 }
 

--- a/AlphaWallet/Browser/ViewControllers/MasterBrowserViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/MasterBrowserViewController.swift
@@ -69,11 +69,11 @@ final class MasterBrowserViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         if let navigationController = navigationController, navigationController.isBeingPresented {
-            browserViewController.browserNavBar?.closeButton.isHidden = false
+            browserViewController.setUpCloseButtonAs(hidden: false)
         } else if isBeingPresented {
-            browserViewController.browserNavBar?.closeButton.isHidden = false
+            browserViewController.setUpCloseButtonAs(hidden: false)
         } else {
-            browserViewController.browserNavBar?.closeButton.isHidden = true
+            browserViewController.setUpCloseButtonAs(hidden: true)
         }
     }
 


### PR DESCRIPTION
For #669 