### PR TITLE
Fix: Crypto Kitty thumbnail appears in wrong cell upon cell reuse

### DIFF
--- a/AlphaWallet/Redeem/Views/TokenListFormatRowView.swift
+++ b/AlphaWallet/Redeem/Views/TokenListFormatRowView.swift
@@ -182,6 +182,7 @@ class TokenListFormatRowView: UIView {
 
         subtitleLabel.text = viewModel.subtitle
 
+        self.thumbnailImageView.image = nil
         //TODO cancel the request if we reuse the cell before it's finished downloading
         if let url = viewModel.thumbnailImageUrl {
             var request = URLRequest(url: url)


### PR DESCRIPTION
For #689 This PR fixes a cell reuse problem:

After scrolling in the crypto kitty cards screen, a card which goes offscreen and back again might display another kitty's thumbnail. Especially obvious if the kitty doesn't have a thumbnail yet.