### PR TITLE
Speedup auto-detect tokens (upon startup) by removing, now, unnecessary delay between fetching details for each contract detected

### DIFF
--- a/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
+++ b/AlphaWallet/Tokens/Coordinators/TokensCoordinator.swift
@@ -110,9 +110,6 @@ class TokensCoordinator: Coordinator {
                             }
                         }
                     }
-                    //TODO remove this and the outer DispatchQueue.global().async {} once GetNameCoordinator and related coordinators use promise properly. Must test with contract that auto-detects many tokens (24 is good enough)
-                    let millionthOfSecondsToSleep: UInt32 = 300000
-                    usleep(millionthOfSecondsToSleep)
                 }
 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {


### PR DESCRIPTION
This PR removes the unnecessary delay between fetching details for each contract that is auto- detected at startup. This delay was needed as a hack earlier to keep things running when the web3swift pod didn't expose promises directly, and instead every RPC call was blocking the thread it was running on. Removing the delay since #683 now uses promises correctly.

This speedup is most noticeable when importing a wallet with many tokens, like 0x007 on Ropsten.