### PR TITLE
Fix: access to localization strings for Dapp browser was not going through R

### DIFF
--- a/AlphaWallet/Browser/ViewControllers/BookmarkViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/BookmarkViewController.swift
@@ -33,7 +33,7 @@ final class BookmarkViewController: UIViewController {
         tableView.rowHeight = 60
         tableView.register(R.nib.bookmarkViewCell(), forCellReuseIdentifier: R.nib.bookmarkViewCell.name)
         view.addSubview(tableView)
-        emptyView = EmptyView(title: NSLocalizedString("bookmarks.noBookmarks.label.title", value: "No bookmarks yet!", comment: ""))
+        emptyView = EmptyView(title: R.string.localizable.browserNoBookmarksLabelTitle())
 
         NSLayoutConstraint.activate([
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -55,7 +55,7 @@ final class BookmarkViewController: UIViewController {
     }
 
     func confirmDelete(bookmark: Bookmark, index: IndexPath) {
-        confirm(title: NSLocalizedString("browser.bookmarks.confirm.delete.title", value: "Are you sure you would like to delete this bookmark?", comment: ""),
+        confirm(title: R.string.localizable.browserBookmarksConfirmDeleteTitle(),
                 okTitle: R.string.localizable.delete(),
                 okStyle: .destructive) { [weak self] result in
                     guard let strongSelf = self else { return }

--- a/AlphaWallet/Browser/ViewControllers/HistoryViewController.swift
+++ b/AlphaWallet/Browser/ViewControllers/HistoryViewController.swift
@@ -29,7 +29,7 @@ final class HistoryViewController: UIViewController {
         tableView.rowHeight = 60
         tableView.register(R.nib.bookmarkViewCell(), forCellReuseIdentifier: R.nib.bookmarkViewCell.name)
         view.addSubview(tableView)
-        emptyView = EmptyView(title: NSLocalizedString("history.noHistory.label.title", value: "No history yet!", comment: ""))
+        emptyView = EmptyView(title: R.string.localizable.browserNoHistoryLabelTitle())
 
         NSLayoutConstraint.activate([
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -98,7 +98,7 @@ extension HistoryViewController: UITableViewDelegate {
         if editingStyle == .delete {
             let history = viewModel.item(for: indexPath)
             confirm(
-                title: NSLocalizedString("Are you sure you would like to delete?", value: "Are you sure you would like to delete?", comment: ""),
+                title: R.string.localizable.browserHistoryConfirmDeleteTitle(),
                 okTitle: R.string.localizable.delete(),
                 okStyle: .destructive
             ) { [weak self] result in

--- a/AlphaWallet/Browser/Views/BrowserErrorView.swift
+++ b/AlphaWallet/Browser/Views/BrowserErrorView.swift
@@ -26,7 +26,7 @@ final class BrowserErrorView: UIView {
     lazy var reloadButton: Button = {
         let button = Button(size: .normal, style: .borderless)
         button.addTarget(self, action: #selector(reloadTapped), for: .touchUpInside)
-        button.setTitle(NSLocalizedString("browser.reload.button.title", value: "Reload", comment: ""), for: .normal)
+        button.setTitle(R.string.localizable.browserReloadButtonTitle(), for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.sizeToFit()
         return button

--- a/AlphaWallet/Browser/Views/BrowserNavigationBar.swift
+++ b/AlphaWallet/Browser/Views/BrowserNavigationBar.swift
@@ -36,7 +36,7 @@ final class BrowserNavigationBar: UINavigationBar {
         textField.clearButtonMode = .whileEditing
         textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 6, height: 30))
         textField.leftViewMode = .always
-        textField.placeholder = NSLocalizedString("browser.url.textfield.placeholder", value: "Search or enter website url", comment: "")
+        textField.placeholder = R.string.localizable.browserUrlTextfieldPlaceholder()
         textField.keyboardType = .webSearch
 
         moreButton.translatesAutoresizingMaskIntoConstraints = false

--- a/AlphaWallet/Localization/en.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/en.lproj/Localizable.strings
@@ -133,6 +133,11 @@
 "browser.reload.button.title" = "Reload";
 "browser.addbookmark.button.title" = "Add Bookmark";
 "browser.tabbar.item.title" = "Browser";
+"browser.history.confirm.delete.title" = "Are you sure you would like to delete?";
+"browser.noHistory.label.title" = "No history yet";
+"browser.bookmarks.confirm.delete.title" = "Are you sure you would like to delete this bookmark?";
+"browser.noBookmarks.label.title" = "No bookmarks yet!";
+"browser.url.textfield.placeholder" = "Search or enter website URL";
 "configureTransaction.gasPriceGwei.label.title" = "Gas Price (Gwei)";
 "enterPassword.confirmPassword.textField.placeholder" = "Confirm Password";
 "enterPassword.navigation.title" = "Backup Password";

--- a/AlphaWallet/Localization/es.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/es.lproj/Localizable.strings
@@ -89,6 +89,11 @@
 "browser.reload.button.title" = "Reload";
 "browser.addbookmark.button.title" = "Add Bookmark";
 "browser.tabbar.item.title" = "Browser";
+"browser.history.confirm.delete.title" = "Are you sure you would like to delete?";
+"browser.noHistory.label.title" = "No history yet";
+"browser.bookmarks.confirm.delete.title" = "Are you sure you would like to delete this bookmark?";
+"browser.noBookmarks.label.title" = "No bookmarks yet!";
+"browser.url.textfield.placeholder" = "Search or enter website URL";
 "configureTransaction.data.label.title" = "Datos de transacción (Opcional)";
 "confirmPayment.data.label.title" = "Datos";
 "Contract Address" = "Contract Address";

--- a/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
+++ b/AlphaWallet/Localization/zh-Hans.lproj/Localizable.strings
@@ -133,6 +133,11 @@
 "browser.reload.button.title" = "刷新";
 "browser.addbookmark.button.title" = "添加书签";
 "browser.tabbar.item.title" = "浏览器";
+"browser.history.confirm.delete.title" = "Are you sure you would like to delete?";
+"browser.noHistory.label.title" = "No history yet";
+"browser.bookmarks.confirm.delete.title" = "Are you sure you would like to delete this bookmark?";
+"browser.noBookmarks.label.title" = "No bookmarks yet!";
+"browser.url.textfield.placeholder" = "Search or enter website URL";
 "configureTransaction.gasPriceGwei.label.title" = "Gas费用 (Gwei)";
 "enterPassword.confirmPassword.textField.placeholder" = "确认密码";
 "enterPassword.navigation.title" = "备份密码";


### PR DESCRIPTION
Missing the benefits of static type checking. Also easier to miss not localised strings. Like in this case.