### PR TITLE
Allow watched wallets to tap to view tokens, but with the transfer/redeem/sell buttons disabled

### DIFF
--- a/AlphaWallet/InCoordinator.swift
+++ b/AlphaWallet/InCoordinator.swift
@@ -388,6 +388,9 @@ class InCoordinator: Coordinator {
         switch (type, session.account.type) {
         case (.send, .real), (.request, _):
             navigationController.present(tokensCardCoordinator.navigationController, animated: true, completion: nil)
+        case (.send, .watch), (.request, _):
+            tokensCardCoordinator.isReadOnly = true
+            navigationController.present(tokensCardCoordinator.navigationController, animated: true, completion: nil)
         case (_, _):
             navigationController.displayError(error: InCoordinatorError.onlyWatchAccount)
         }

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -39,6 +39,12 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
     let sellButton = UIButton(type: .system)
     let transferButton = UIButton(type: .system)
 
+    var isReadOnly = false {
+        didSet {
+            configure()
+        }
+    }
+
     init(config: Config, tokenObject: TokenObject, account: Wallet, tokensStorage: TokensDataStore, viewModel: TokensCardViewModel) {
         self.config = config
         self.tokenObject = tokenObject
@@ -56,6 +62,7 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
 
         tableView.register(TokenCardTableViewCellWithoutCheckbox.self, forCellReuseIdentifier: TokenCardTableViewCellWithoutCheckbox.identifier)
         tableView.register(TokenListFormatTableViewCellWithoutCheckbox.self, forCellReuseIdentifier: TokenListFormatTableViewCellWithoutCheckbox.identifier)
+
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.delegate = self
         tableView.separatorStyle = .none
@@ -138,14 +145,17 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
         tableView.tableHeaderView = header
 
         redeemButton.setTitleColor(viewModel.buttonTitleColor, for: .normal)
+        redeemButton.setTitleColor(viewModel.disabledButtonTitleColor, for: .disabled)
 		redeemButton.backgroundColor = viewModel.buttonBackgroundColor
         redeemButton.titleLabel?.font = viewModel.buttonFont
 
         sellButton.setTitleColor(viewModel.buttonTitleColor, for: .normal)
+        sellButton.setTitleColor(viewModel.disabledButtonTitleColor, for: .disabled)
         sellButton.backgroundColor = viewModel.buttonBackgroundColor
         sellButton.titleLabel?.font = viewModel.buttonFont
 
         transferButton.setTitleColor(viewModel.buttonTitleColor, for: .normal)
+        transferButton.setTitleColor(viewModel.disabledButtonTitleColor, for: .disabled)
         transferButton.backgroundColor = viewModel.buttonBackgroundColor
         transferButton.titleLabel?.font = viewModel.buttonFont
 
@@ -161,6 +171,7 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
             redeemButton.isHidden = true
             sellButton.isHidden = true
         }
+        [redeemButton, sellButton, transferButton].forEach { $0.isEnabled = !isReadOnly }
 
         tableView.reloadData()
     }

--- a/AlphaWallet/Tokens/ViewModels/TokensCardViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/TokensCardViewModel.swift
@@ -31,6 +31,10 @@ struct TokensCardViewModel {
         return Colors.appWhite
     }
 
+    var disabledButtonTitleColor: UIColor {
+        return Colors.darkGray
+    }
+
     var buttonBackgroundColor: UIColor {
         return Colors.appHighlightGreen
     }

--- a/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
+++ b/AlphaWallet/Transactions/Coordinators/TokensCardCoordinator.swift
@@ -44,6 +44,11 @@ class TokensCardCoordinator: NSObject, Coordinator {
     var coordinators: [Coordinator] = []
     var ethPrice: Subscribable<Double>
     let assetDefinitionStore: AssetDefinitionStore
+    var isReadOnly = false {
+        didSet {
+            rootViewController.isReadOnly = isReadOnly
+        }
+    }
 
     init(
             session: WalletSession,


### PR DESCRIPTION
For #738.

Nice, for example, when you watch other people's CryptoKitties.