### PR TITLE
Fix: launch screen if app is launched with call/tether bar visible on phones that doesn't have a notch, like iPhone 8 and earlier

### DIFF
--- a/AlphaWallet/AppDelegate.swift
+++ b/AlphaWallet/AppDelegate.swift
@@ -22,6 +22,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         } catch {
             print("EtherKeystore init issue.")
         }
+        //Status bar hidden at launch so launch screen is not distorted when call/tether bar is activated in phones without a notch, like iPhone 8 and earlier
+        application.isStatusBarHidden = false
         protectionCoordinator.didFinishLaunchingWithOptions()
 
         return true

--- a/AlphaWallet/Info.plist
+++ b/AlphaWallet/Info.plist
@@ -87,6 +87,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
 	<key>UIStatusBarTintParameters</key>


### PR DESCRIPTION
For #748 