### PR TITLE
No longer track latest block number if isAutoFetchingDisabled = true

### DIFF
--- a/AlphaWallet/EtherClient/ChainState.swift
+++ b/AlphaWallet/EtherClient/ChainState.swift
@@ -33,7 +33,11 @@ class ChainState {
     ) {
         self.config = config
         self.defaults = config.defaults
-        self.updateLatestBlock = Timer.scheduledTimer(timeInterval: 6, target: self, selector: #selector(fetch), userInfo: nil, repeats: true)
+        if config.isAutoFetchingDisabled {
+            //No-op
+        } else {
+            self.updateLatestBlock = Timer.scheduledTimer(timeInterval: 6, target: self, selector: #selector(fetch), userInfo: nil, repeats: true)
+        }
     }
 
     func start() {


### PR DESCRIPTION
Had to been using the `isAutoFetchingDisabled` for debugging. Especially useful to hardcode it to `true` when stepping through RPC calls.