### PR TITLE
Speed up CryptoKitty cards and fix crash due to certain CryptoKitty images

### DIFF
--- a/AlphaWallet.xcodeproj/project.pbxproj
+++ b/AlphaWallet.xcodeproj/project.pbxproj
@@ -273,9 +273,11 @@
 		5E7C71F8050CCF990539B293 /* LockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C79D674D45A07E694CE31 /* LockView.swift */; };
 		5E7C7208A83399C27AE57E44 /* ImportWalletHelpBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C70CC85B337061151724E /* ImportWalletHelpBubbleView.swift */; };
 		5E7C724638271FD2FA0EB93C /* BaseTokenListFormatTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C734D61C0347C1638A1F7 /* BaseTokenListFormatTableViewCell.swift */; };
+		5E7C725AC96979DEF4DE8B85 /* GenerateCryptoKittyPNGFromSVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7BCCCFE7B99162518FB7 /* GenerateCryptoKittyPNGFromSVG.swift */; };
 		5E7C72670E16AFB8DAF64673 /* OnboardingPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7E24936CC2190D2A16C2 /* OnboardingPageViewModel.swift */; };
 		5E7C728CDF33FBDBA47F71A6 /* MarketplaceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C794F8EBAEE5E8F2821C2 /* MarketplaceViewController.swift */; };
 		5E7C729D43F311810652B1D5 /* UIActivityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C78E5C8FAEA752B32626D /* UIActivityViewController.swift */; };
+		5E7C729FA0EC60113B031391 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C772DC28C5110021894E3 /* ImageCache.swift */; };
 		5E7C72AF95DCE8BC65490BCA /* StatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7B82CC07F290B9CAA4E4 /* StatusViewController.swift */; };
 		5E7C72B0A10A92E591696E48 /* ContactUsBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C7AE6FAE0DF969B4F52E9 /* ContactUsBannerView.swift */; };
 		5E7C72C8A15397C5A40BFE76 /* WhatIsEthereumInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7C774BCA281E4B077DBBFA /* WhatIsEthereumInfoViewController.swift */; };
@@ -915,6 +917,7 @@
 		5E7C76D3CFA12C2236E73E10 /* TransferTokensCardViaWalletAddressViewControllerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransferTokensCardViaWalletAddressViewControllerViewModel.swift; sourceTree = "<group>"; };
 		5E7C77061BEF269BCE358086 /* BaseTokenCardTableViewCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseTokenCardTableViewCellViewModel.swift; sourceTree = "<group>"; };
 		5E7C7721E0E4D4EFDD35E196 /* ScanQRCodeCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanQRCodeCoordinator.swift; sourceTree = "<group>"; };
+		5E7C772DC28C5110021894E3 /* ImageCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		5E7C77316522DF2B256F1F92 /* TokensCardViewControllerHeaderViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokensCardViewControllerHeaderViewModel.swift; sourceTree = "<group>"; };
 		5E7C774BCA281E4B077DBBFA /* WhatIsEthereumInfoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhatIsEthereumInfoViewController.swift; sourceTree = "<group>"; };
 		5E7C7752CDF1417A704035C3 /* BookmarkViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BookmarkViewController.swift; sourceTree = "<group>"; };
@@ -970,6 +973,7 @@
 		5E7C7B9220E616F82EDA956F /* PasscodeCharacterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasscodeCharacterView.swift; sourceTree = "<group>"; };
 		5E7C7BA578BE5FB0E613A6D6 /* ChooseTokenCardTransferModeViewControllerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChooseTokenCardTransferModeViewControllerViewModel.swift; sourceTree = "<group>"; };
 		5E7C7BAC4E511FE8446D212F /* Favicon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Favicon.swift; sourceTree = "<group>"; };
+		5E7C7BCCCFE7B99162518FB7 /* GenerateCryptoKittyPNGFromSVG.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenerateCryptoKittyPNGFromSVG.swift; sourceTree = "<group>"; };
 		5E7C7BD9B4BDAFC2D9EBD741 /* StatusViewControllerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusViewControllerViewModel.swift; sourceTree = "<group>"; };
 		5E7C7BF09AD68C113D58344C /* LocalesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalesViewController.swift; sourceTree = "<group>"; };
 		5E7C7BF5551BF64D2AE8AD66 /* AssetDefinitionDiskBackingStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssetDefinitionDiskBackingStore.swift; sourceTree = "<group>"; };
@@ -2198,6 +2202,7 @@
 				CCCD74FF1FD2D95F004A087D /* Coordinators */,
 				2931120E1FC4ADBE00966EEA /* ViewModels */,
 				29FC9BC41F830880000209CD /* Initializers */,
+				5E7C772DC28C5110021894E3 /* ImageCache.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -2367,6 +2372,7 @@
 			isa = PBXGroup;
 			children = (
 				442FC20E6470B92A46479342 /* TokenAdaptor.swift */,
+				5E7C7629662FB4983E0EBFEB /* CryptoKitties */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -2507,6 +2513,14 @@
 				5E7C781F82F9E4903C460E33 /* ImportMagicTokenCardRowViewModel.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		5E7C7629662FB4983E0EBFEB /* CryptoKitties */ = {
+			isa = PBXGroup;
+			children = (
+				5E7C7BCCCFE7B99162518FB7 /* GenerateCryptoKittyPNGFromSVG.swift */,
+			);
+			path = CryptoKitties;
 			sourceTree = "<group>";
 		};
 		5E7C76A2DAB62A6824F37749 /* Sell */ = {
@@ -3977,6 +3991,8 @@
 				5E7C749B7C5CBC729B7E256F /* CryptoKittyCAttributeCell.swift in Sources */,
 				5E7C773E3E3BBEB65C51DF2A /* UIStackView.swift in Sources */,
 				5E7C760D5AF93B79BB9BDB5A /* CryptoKittyCAttributeCellViewModel.swift in Sources */,
+				5E7C725AC96979DEF4DE8B85 /* GenerateCryptoKittyPNGFromSVG.swift in Sources */,
+				5E7C729FA0EC60113B031391 /* ImageCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlphaWallet/Core/ImageCache.swift
+++ b/AlphaWallet/Core/ImageCache.swift
@@ -1,0 +1,40 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import Foundation
+import UIKit
+
+//TODO possible performance improvement if we cache in-memory?
+class ImageCache {
+    private static let defaultDirectoryName = "imageCache"
+
+    private let documentsDirectory = URL(fileURLWithPath: NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)[0])
+    private let directoryName: String
+    lazy var directory = documentsDirectory.appendingPathComponent(directoryName)
+
+    init(directoryName: String = defaultDirectoryName) {
+        self.directoryName = directoryName
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    private func fullURL(for key: String) -> URL {
+        return directory.appendingPathComponent(filename(fromKey: key))
+    }
+
+    private func filename(fromKey key: String) -> String {
+        return "\(key).png"
+    }
+
+    subscript(key: String) -> UIImage? {
+        get {
+            let url = fullURL(for: key)
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            return UIImage(data: data, scale: UIScreen.main.scale)
+        }
+        set(image) {
+            guard let image = image else { return }
+            let url = fullURL(for: key)
+            let data = UIImagePNGRepresentation(image)
+            try? data?.write(to: url)
+        }
+    }
+}

--- a/AlphaWallet/PushNotificationsCoordinator.swift
+++ b/AlphaWallet/PushNotificationsCoordinator.swift
@@ -63,7 +63,12 @@ class PushNotificationsCoordinator: NSObject, Coordinator {
 
 extension PushNotificationsCoordinator: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        completionHandler([.badge, .alert,.sound])
+        if notification.request.identifier == Constants.etherReceivedNotificationIdentifier {
+            completionHandler([.badge, .alert, .sound])
+        } else {
+            //don't display notifications from SNS yet
+            completionHandler([])
+        }
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {

--- a/AlphaWallet/Tokens/Helpers/CryptoKitties/GenerateCryptoKittyPNGFromSVG.swift
+++ b/AlphaWallet/Tokens/Helpers/CryptoKitties/GenerateCryptoKittyPNGFromSVG.swift
@@ -1,0 +1,86 @@
+// Copyright © 2018 Stormbird PTE. LTD.
+
+import Foundation
+import UIKit
+import Macaw
+import PromiseKit
+
+class GenerateCryptoKittyPNGFromSVG {
+    private let imageCache = ImageCache()
+    private var promises = [URL: Promise<UIImage>]()
+
+    func withDownloadedImage(fromURL url: URL?, forTokenId tokenId: String?) -> Promise<UIImage> {
+        guard let tokenId = tokenId else {
+            return Promise { $0.resolve(nil, GenerationError()) }
+        }
+        guard let url = url else {
+            return Promise { $0.resolve(nil, GenerationError()) }
+        }
+
+        if let promise = promises[url] {
+            return promise
+        }
+
+        if let image = cachedImage(forKittyId: tokenId) {
+            return Promise { $0.resolve(image, nil) }
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.cachePolicy = .returnCacheDataElseLoad
+        let promise = Alamofire.request(request).responseData().then { data, response -> Promise<UIImage> in
+            let imagePromise = self.generateImage(data: data)
+            return imagePromise
+        }.then { image -> Promise<UIImage> in
+            self.cache(image: image, forKittyId: tokenId)
+            return Promise { $0.resolve(image, nil) }
+        }
+        promises[url] = promise
+        return promise
+    }
+
+    private func generateImage(data: Data) -> Promise<UIImage> {
+        return Promise { seal in
+            guard let string = String(data: data, encoding: .utf8), let node = try? SVGParser.parse(text: string), let group = node as? Group else {
+                seal.resolve(nil, GenerationError())
+                return
+            }
+            let widestWidthPossiblyNeeded = UIScreen.main.bounds.width
+            let size = CGSize(width: widestWidthPossiblyNeeded, height: widestWidthPossiblyNeeded)
+            let screenScale = UIScreen.main.scale
+            DispatchQueue.global(qos: .userInitiated).async {
+                UIGraphicsBeginImageContextWithOptions(size, false, screenScale)
+                guard let graphicsContext = UIGraphicsGetCurrentContext() else {
+                    UIGraphicsEndImageContext()
+                    seal.resolve(nil, GenerationError())
+                    return
+                }
+                graphicsContext.concatenate(LayoutHelper().getTransform(group, ContentLayout.of(contentMode: .scaleAspectFit), size.toMacaw()))
+                let renderer = RenderUtils.createNodeRenderer(group)
+                renderer.render(in: graphicsContext, force: false, opacity: group.opacity)
+                guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
+                    UIGraphicsEndImageContext()
+                    seal.resolve(nil, GenerationError())
+                    return
+                }
+                UIGraphicsEndImageContext()
+                seal.resolve(image, nil)
+            }
+        }
+    }
+
+    private func cryptoKittyImageKey(fromKittyId kittyId: String) -> String {
+        return "cryptokitty-\(kittyId)"
+    }
+
+    private func cachedImage(forKittyId kittyId: String) -> UIImage? {
+        return imageCache[cryptoKittyImageKey(fromKittyId: kittyId)]
+    }
+
+    private func cache(image: UIImage, forKittyId kittyId: String) {
+        imageCache[cryptoKittyImageKey(fromKittyId: kittyId)] = image
+    }
+
+    private struct GenerationError: LocalizedError {
+    }
+}

--- a/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
+++ b/AlphaWallet/Tokens/ViewControllers/TokensCardViewController.swift
@@ -211,7 +211,7 @@ class TokensCardViewController: UIViewController, TokenVerifiableStatusViewContr
     }
 
     private func animateRowHeightChanges(for indexPaths: [IndexPath], in tableview: UITableView) {
-        tableView.reloadData()
+        tableview.reloadRows(at: indexPaths, with: .automatic)
     }
 }
 

--- a/AlphaWallet/Tokens/ViewModels/CryptoKittyCardRowViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/CryptoKittyCardRowViewModel.swift
@@ -1,11 +1,23 @@
 // Copyright © 2018 Stormbird PTE. LTD.
 
 import UIKit
+import PromiseKit
 
 struct CryptoKittyCardRowViewModel {
-    var tokenHolder: TokenHolder
+    static var imageGenerator = GenerateCryptoKittyPNGFromSVG()
 
-    var areDetailsVisible: Bool
+    let tokenHolder: TokenHolder
+
+    let areDetailsVisible: Bool
+
+    var bigImage: Promise<UIImage>?
+
+    init(tokenHolder: TokenHolder, areDetailsVisible: Bool) {
+        self.tokenHolder = tokenHolder
+        self.areDetailsVisible = areDetailsVisible
+        let tokenId = tokenHolder.values["tokenId"] as? String
+        self.bigImage = CryptoKittyCardRowViewModel.imageGenerator.withDownloadedImage(fromURL: imageUrl, forTokenId: tokenId)
+    }
 
     var contentsBackgroundColor: UIColor {
         return Colors.appWhite

--- a/Podfile
+++ b/Podfile
@@ -28,8 +28,9 @@ target 'AlphaWallet' do
   pod 'SwiftyJSON'
   pod 'web3swift', :git => 'https://github.com/alpha-wallet/web3swift.git', :commit => '2b3c5ee878212ce70768568def7e727f0f1ebf86'
   pod 'SAMKeychain'
-  #pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git', :commit => '733acf66e44a02396efc8a6f445d190af592d544'
-  pod "Macaw", "0.9.2"
+  pod 'PromiseKit/CorePromise'
+  pod 'PromiseKit/Alamofire'
+  pod "Macaw", :git => 'https://github.com/alpha-wallet/Macaw.git', :commit => 'c13e70e63dd1a2554b59e0aa75c12b93e2ee9dd8'
   pod 'AWSSNS'
   # pod 'AWSCognito'
   target 'AlphaWalletTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -36,6 +36,9 @@ PODS:
     - PromiseKit/CorePromise (= 6.3.5)
     - PromiseKit/Foundation (= 6.3.5)
     - PromiseKit/UIKit (= 6.3.5)
+  - PromiseKit/Alamofire (6.3.5):
+    - Alamofire (~> 4.0)
+    - PromiseKit/CorePromise
   - PromiseKit/CorePromise (6.3.5)
   - PromiseKit/Foundation (6.3.5):
     - PromiseKit/CorePromise
@@ -88,9 +91,11 @@ DEPENDENCIES:
   - JSONRPCKit (~> 2.0.0)
   - KeychainSwift
   - Kingfisher (~> 4.0)
-  - Macaw (= 0.9.2)
+  - Macaw (from `https://github.com/alpha-wallet/Macaw.git`, commit `c13e70e63dd1a2554b59e0aa75c12b93e2ee9dd8`)
   - MBProgressHUD
   - Moya (~> 10.0.1)
+  - PromiseKit/Alamofire
+  - PromiseKit/CorePromise
   - QRCodeReaderViewController (from `https://github.com/yannickl/QRCodeReaderViewController.git`, branch `master`)
   - R.swift
   - RealmSwift (~> 3.9)
@@ -121,7 +126,6 @@ SPEC REPOS:
     - KeychainSwift
     - Kingfisher
     - libsodium
-    - Macaw
     - MBProgressHUD
     - Moya
     - PromiseKit
@@ -141,6 +145,9 @@ SPEC REPOS:
     - TrezorCrypto
 
 EXTERNAL SOURCES:
+  Macaw:
+    :commit: c13e70e63dd1a2554b59e0aa75c12b93e2ee9dd8
+    :git: https://github.com/alpha-wallet/Macaw.git
   QRCodeReaderViewController:
     :branch: master
     :git: https://github.com/yannickl/QRCodeReaderViewController.git
@@ -157,6 +164,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/alpha-wallet/web3swift.git
 
 CHECKOUT OPTIONS:
+  Macaw:
+    :commit: c13e70e63dd1a2554b59e0aa75c12b93e2ee9dd8
+    :git: https://github.com/alpha-wallet/Macaw.git
   QRCodeReaderViewController:
     :commit: 80bd79cbeede842949b229f81bc6328f53701c5a
     :git: https://github.com/yannickl/QRCodeReaderViewController.git
@@ -213,6 +223,6 @@ SPEC CHECKSUMS:
   TrustWeb3Provider: 50fa391bdf170feb43dd4419992931510a5751d8
   web3swift: ec721fe509a4b3ca7abdf027d186d07fce65be8f
 
-PODFILE CHECKSUM: 5014a448c34c0fb838c8d9510ff58582b9d0141d
+PODFILE CHECKSUM: 5f466c536c14e9c8f9d033b78ce18bfa41c167b1
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
This PR

* Converts SVG to PNG and cache the PNGs
* No-longer blocks UI while displaying CryptoKitty image #765 
* Fix: crash due to certain CryptoKitty images (might not be exhaustive) #764 
* has a smoother animation when expanding/collapsing CryptoKitty cards

Includes using a fork to the Macaw pod. Needs some followup work to report a bug and submit a PR