### PR TITLE
Read and use CryptoKitty background color from OpenSea API

### DIFF
--- a/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
+++ b/AlphaWallet/Tokens/Helpers/TokenAdaptor.swift
@@ -142,6 +142,7 @@ class TokenAdaptor {
         values["imageUrl"] = cat.imageUrl
         values["thumbnailUrl"] = cat.thumbnailUrl
         values["externalLink"] = cat.externalLink
+        values["backgroundColor"] = cat.backgroundColor
         values["traits"] = cat.traits
 
         let status: Token.Status

--- a/AlphaWallet/Tokens/Types/CryptoKitty.swift
+++ b/AlphaWallet/Tokens/Types/CryptoKitty.swift
@@ -11,6 +11,7 @@ struct CryptoKitty: Codable {
     let thumbnailUrl: String
     let imageUrl: String
     let externalLink: String
+    let backgroundColor: String?
     let traits: [CryptoKittyTrait]
     var generationTrait: CryptoKittyTrait? {
         return traits.first(where: { $0.type == CryptoKitty.generationTraitName  })

--- a/AlphaWallet/Tokens/Types/TokensDataStore.swift
+++ b/AlphaWallet/Tokens/Types/TokensDataStore.swift
@@ -250,6 +250,7 @@ class TokensDataStore {
                 let thumbnailUrl = each["image_thumbnail_url"].stringValue
                 let imageUrl = each["image_url"].stringValue
                 let externalLink = each["external_link"].stringValue
+                let backgroundColor = each["background_color"].stringValue
                 var traits = [CryptoKittyTrait]()
                 for each in each["traits"].arrayValue {
                     let traitCount = each["trait_count"].intValue
@@ -258,7 +259,7 @@ class TokensDataStore {
                     let trait = CryptoKittyTrait(count: traitCount, type: traitType, value: traitValue)
                     traits.append(trait)
                 }
-                let cat = CryptoKitty(tokenId: tokenId, description: description, thumbnailUrl: thumbnailUrl, imageUrl: imageUrl, externalLink: externalLink, traits: traits)
+                let cat = CryptoKitty(tokenId: tokenId, description: description, thumbnailUrl: thumbnailUrl, imageUrl: imageUrl, externalLink: externalLink, backgroundColor: backgroundColor, traits: traits)
                 if let encodedJson = try? JSONEncoder().encode(cat), let jsonString = String(data: encodedJson, encoding: .utf8) {
                     results.append(jsonString)
                 } else {

--- a/AlphaWallet/Tokens/ViewModels/CryptoKittyCardRowViewModel.swift
+++ b/AlphaWallet/Tokens/ViewModels/CryptoKittyCardRowViewModel.swift
@@ -12,7 +12,11 @@ struct CryptoKittyCardRowViewModel {
     }
 
     var bigImageBackgroundColor: UIColor {
-        return UIColor(red: 247, green: 197, blue: 196)
+        if let color =  tokenHolder.values["backgroundColor"] as? String, !color.isEmpty {
+            return UIColor(hex: color)
+        } else {
+            return UIColor(red: 247, green: 197, blue: 196)
+        }
     }
 
     var titleColor: UIColor {


### PR DESCRIPTION
Read background color for CryptoKitty image from OpenSea API output.

cc @JamesSmartCell. Example API output:

   "assets" : [
      {
        ...
         "token_id" : "507300",
         "background_color" : "ede2f5",
         ...
     }
