### PR TITLE
Handle when CryptoKitties images are sometimes not SVG, but PNG

### DIFF
--- a/AlphaWallet/Core/ImageCache.swift
+++ b/AlphaWallet/Core/ImageCache.swift
@@ -28,7 +28,7 @@ class ImageCache {
         get {
             let url = fullURL(for: key)
             guard let data = try? Data(contentsOf: url) else { return nil }
-            return UIImage(data: data, scale: UIScreen.main.scale)
+            return ImageCache.image(fromData: data)
         }
         set(image) {
             guard let image = image else { return }
@@ -36,5 +36,9 @@ class ImageCache {
             let data = UIImagePNGRepresentation(image)
             try? data?.write(to: url)
         }
+    }
+
+    static func image(fromData data: Data) -> UIImage? {
+        return UIImage(data: data, scale: UIScreen.main.scale)
     }
 }

--- a/AlphaWallet/Tokens/Helpers/CryptoKitties/GenerateCryptoKittyPNGFromSVG.swift
+++ b/AlphaWallet/Tokens/Helpers/CryptoKitties/GenerateCryptoKittyPNGFromSVG.swift
@@ -8,13 +8,14 @@ import PromiseKit
 class GenerateCryptoKittyPNGFromSVG {
     private let imageCache = ImageCache()
     private var promises = [URL: Promise<UIImage>]()
+    private var rasterizedImageFileExtensions = ["png", "jpg", "jpeg"]
 
     func withDownloadedImage(fromURL url: URL?, forTokenId tokenId: String?) -> Promise<UIImage> {
         guard let tokenId = tokenId else {
-            return Promise { $0.resolve(nil, GenerationError()) }
+            return Promise { $0.resolve(nil, GenerationError(errorDescription: "No tokenId")) }
         }
         guard let url = url else {
-            return Promise { $0.resolve(nil, GenerationError()) }
+            return Promise { $0.resolve(nil, GenerationError(errorDescription: "No URL")) }
         }
 
         if let promise = promises[url] {
@@ -28,9 +29,21 @@ class GenerateCryptoKittyPNGFromSVG {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.cachePolicy = .returnCacheDataElseLoad
+        //OK to retain strong self reference because we can still download the image and cache it for future sessions
         let promise = Alamofire.request(request).responseData().then { data, response -> Promise<UIImage> in
-            let imagePromise = self.generateImage(data: data)
-            return imagePromise
+            let imageFileExtension = url.pathExtension.lowercased()
+            if self.rasterizedImageFileExtensions.contains(imageFileExtension) {
+                if let image = ImageCache.image(fromData: data) {
+                    //TODO resize the image if it's drastically bigger than what we are using in the app
+                    self.cache(image: image, forKittyId: tokenId)
+                    return Promise { $0.resolve(image, nil) }
+                } else {
+                    return Promise { $0.resolve(nil, GenerationError(errorDescription: "Can't create image from data interpreted as PNG. URL: \(url) tokenId: \(tokenId)")) }
+                }
+            } else {
+                let imagePromise = self.generateImage(data: data, fromURL: url, forTokenId: tokenId)
+                return imagePromise
+            }
         }.then { image -> Promise<UIImage> in
             self.cache(image: image, forKittyId: tokenId)
             return Promise { $0.resolve(image, nil) }
@@ -39,10 +52,10 @@ class GenerateCryptoKittyPNGFromSVG {
         return promise
     }
 
-    private func generateImage(data: Data) -> Promise<UIImage> {
+    private func generateImage(data: Data, fromURL url: URL, forTokenId tokenId: String) -> Promise<UIImage> {
         return Promise { seal in
             guard let string = String(data: data, encoding: .utf8), let node = try? SVGParser.parse(text: string), let group = node as? Group else {
-                seal.resolve(nil, GenerationError())
+                seal.resolve(nil, GenerationError(errorDescription: "Can't create string or node from data from URL: \(url) tokenId: \(tokenId)"))
                 return
             }
             let widestWidthPossiblyNeeded = UIScreen.main.bounds.width
@@ -52,7 +65,7 @@ class GenerateCryptoKittyPNGFromSVG {
                 UIGraphicsBeginImageContextWithOptions(size, false, screenScale)
                 guard let graphicsContext = UIGraphicsGetCurrentContext() else {
                     UIGraphicsEndImageContext()
-                    seal.resolve(nil, GenerationError())
+                    seal.resolve(nil, GenerationError(errorDescription: "Can't retrieve new graphics context from URL: \(url) tokenId: \(tokenId)"))
                     return
                 }
                 graphicsContext.concatenate(LayoutHelper().getTransform(group, ContentLayout.of(contentMode: .scaleAspectFit), size.toMacaw()))
@@ -60,7 +73,7 @@ class GenerateCryptoKittyPNGFromSVG {
                 renderer.render(in: graphicsContext, force: false, opacity: group.opacity)
                 guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
                     UIGraphicsEndImageContext()
-                    seal.resolve(nil, GenerationError())
+                    seal.resolve(nil, GenerationError(errorDescription: "Can't retrieve image from graphics context from URL: \(url) tokenId: \(tokenId)"))
                     return
                 }
                 UIGraphicsEndImageContext()
@@ -82,5 +95,6 @@ class GenerateCryptoKittyPNGFromSVG {
     }
 
     private struct GenerationError: LocalizedError {
+        var errorDescription: String
     }
 }


### PR DESCRIPTION
Some image URLs are png instead of svg. This PR checks for png, as well as jpg and jpeg (just in case).

cc @JamesSmartCell example kitty ID: 107923 owned by 0xb1690C08E213a35Ed9bAb7B318DE14420FB57d8C has https://storage.googleapis.com/opensea-prod.appspot.com/0x06012c8cf97bead5deae237070f9587f8e7a266d/107923.png